### PR TITLE
Vite fix to remove auto-added import of @vite/env in worker

### DIFF
--- a/sqlite-wasm/jswasm/sqlite3-bundler-friendly.mjs
+++ b/sqlite-wasm/jswasm/sqlite3-bundler-friendly.mjs
@@ -12309,6 +12309,7 @@ var sqlite3InitModule = (() => {
             };
             const W = new Worker(
               new URL('sqlite3-opfs-async-proxy.js', import.meta.url),
+              /* @vite-ignore */
             );
             W._originalOnError = W.onerror;
             W.onerror = function (err) {


### PR DESCRIPTION
I was experimenting with getting this package working in Nuxt 3, but it would fail to start up because Vite was automatically adding the line `importScripts('/@vite/env')` to the top of sqlite3-opfs-async-proxy.js, which points to nothing in that context and creates a network error.

<img width="525" alt="Screenshot 2023-05-07 at 8 38 56 PM" src="https://user-images.githubusercontent.com/50426566/236711738-cc6963fa-f9f8-4811-a30d-a7c4757cb279.png">

I fixed this by adding a vite-ignore comment where the package initializes the sqlite3-opfs-async-proxy.js worker. After doing this, I was able to get the SQLite demo running with OPFS. See [this repo](https://github.com/DallasHoff/nuxt3-opfs-sqlite-poc) for the Nuxt 3 project I tested with.