### PR TITLE
Exposed the rowMode parameter of exec, plus some small README fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,10 @@ sqlite3InitModule({
 });
 ```
 
+The `db` object above implements the Object Oriented API #1, which is documented
+[here](https://sqlite.org/wasm/doc/tip/api-oo1.md).
+
+
 ### In a worker (with OPFS if available):
 
 > **Warning**
@@ -120,7 +124,7 @@ const sqliteWorkerPath = 'assets/js/sqlite-worker.js';
 // This is the name of your database. It corresponds to the path in the OPFS.
 const filename = '/test.sqlite3';
 
-const sqlite = new Sqlite(filename, sqliteWorkerPath);
+const sqlite = new SqliteClient(filename, sqliteWorkerPath);
 await sqlite.init();
 
 await sqlite.executeSql('CREATE TABLE IF NOT EXISTS test(a,b)');

--- a/README.md
+++ b/README.md
@@ -51,8 +51,7 @@ sqlite3InitModule({
 });
 ```
 
-The `db` object above implements the Object Oriented API #1, which is documented
-[here](https://sqlite.org/wasm/doc/tip/api-oo1.md).
+The `db` object above implements the [Object Oriented API #1](https://sqlite.org/wasm/doc/tip/api-oo1.md).
 
 
 ### In a worker (with OPFS if available):

--- a/README.md
+++ b/README.md
@@ -53,7 +53,6 @@ sqlite3InitModule({
 
 The `db` object above implements the [Object Oriented API #1](https://sqlite.org/wasm/doc/tip/api-oo1.md).
 
-
 ### In a worker (with OPFS if available):
 
 > **Warning**

--- a/src/sqlite-client.mjs
+++ b/src/sqlite-client.mjs
@@ -5,8 +5,9 @@ export class SqliteClient {
 
   dbFile = '';
   sqliteWorkerPath = '';
+  rowMode = 'object';
 
-  constructor(dbFile, sqliteWorkerPath) {
+  constructor(dbFile, sqliteWorkerPath, rowMode) {
     if (typeof dbFile !== 'string') {
       throw new Error(
         `The 'dbFile' parameter passed to the 'SqliteClient' constructor must be of type 'string'. Instead, you passed: '${typeof dbFile}'.`,
@@ -21,6 +22,10 @@ export class SqliteClient {
 
     this.dbFile = dbFile;
     this.sqliteWorkerPath = sqliteWorkerPath;
+    if (rowMode && rowMode !== 'array' && rowMode !== 'object') {
+      throw new Error('Invalid rowMode');
+    }
+    this.rowMode = rowMode || this.rowMode;
   }
 
   async init() {
@@ -32,7 +37,7 @@ export class SqliteClient {
 
     this.sqliteWorker = await new SqliteWorker();
 
-    await this.sqliteWorker.init(this.dbFile);
+    await this.sqliteWorker.init(this.dbFile, this.rowMode);
   }
 
   async executeSql(sqlStatement, bindParameters = []) {

--- a/src/sqlite-worker.mjs
+++ b/src/sqlite-worker.mjs
@@ -6,7 +6,12 @@ const error = (...args) => console.error(...args);
 
 class SqliteWorker {
   db;
-  init(dbFile) {
+  rowMode = 'object';
+  init(dbFile, rowMode) {
+    if (rowMode && rowMode !== 'array' && rowMode !== 'object') {
+      throw new Error('Invalid rowMode');
+    }
+    this.rowMode = rowMode || this.rowMode;
     return new Promise((resolve) => {
       sqlite3InitModule({
         print: log,
@@ -29,7 +34,7 @@ class SqliteWorker {
         sql: sqlStatement,
         bind: bindParameters,
         returnValue: 'resultRows',
-        rowMode: 'array',
+        rowMode: this.rowMode,
       }),
     );
   }


### PR DESCRIPTION
This change does the following:

- Surfaces the rowMode parameter in the bundlide SqliteClient and SqliteWorker. 
- Sets the default to 'object', which seems like the more common case. The first example in both sql.js' and the sqlite3 NPM packages' READMEs both fetch rows as objects.
- Fixes a small issue in the README and adds a pointer to the "OO #1" API docs.