### PR TITLE
fix: update broken import path to use `sqlite3.mjs`

### DIFF
--- a/sqlite-wasm/jswasm/sqlite3-worker1-bundler-friendly.mjs
+++ b/sqlite-wasm/jswasm/sqlite3-worker1-bundler-friendly.mjs
@@ -31,5 +31,5 @@
   - `sqlite3.dir`, if set, treats the given directory name as the
     directory from which `sqlite3.js` will be loaded.
 */
-import { default as sqlite3InitModule } from './sqlite3-bundler-friendly.mjs';
+import { default as sqlite3InitModule } from './sqlite3.mjs';
 sqlite3InitModule().then((sqlite3) => sqlite3.initWorker1API());


### PR DESCRIPTION
The `sqlite3-bundler-friendly.mjs` file was removed in release 3.50.4.

Close #123