### PR TITLE
chore: added more specific types for eConflict param

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -7196,7 +7196,12 @@ declare type CAPI = {
     xConflict:
       | ((
           pCtx: WasmPointer,
-          eConflict: number /* TODO: Can be more specific? */,
+          eConflict:
+            | CAPI['SQLITE_CHANGESET_DATA']
+            | CAPI['SQLITE_CHANGESET_NOTFOUND']
+            | CAPI['SQLITE_CHANGESET_CONFLICT']
+            | CAPI['SQLITE_CHANGESET_FOREIGN_KEY']
+            | CAPI['SQLITE_CHANGESET_CONSTRAINT'],
           pIter: WasmPointer,
         ) =>
           | CAPI['SQLITE_CHANGESET_OMIT']
@@ -7254,7 +7259,12 @@ declare type CAPI = {
     xConflict:
       | ((
           pCtx: WasmPointer,
-          eConflict: number /* TODO: Can be more specific? */,
+          eConflict:
+            | CAPI['SQLITE_CHANGESET_DATA']
+            | CAPI['SQLITE_CHANGESET_NOTFOUND']
+            | CAPI['SQLITE_CHANGESET_CONFLICT']
+            | CAPI['SQLITE_CHANGESET_FOREIGN_KEY']
+            | CAPI['SQLITE_CHANGESET_CONSTRAINT'],
           pIter: WasmPointer,
         ) =>
           | CAPI['SQLITE_CHANGESET_OMIT']
@@ -7300,8 +7310,13 @@ declare type CAPI = {
     xConflict:
       | ((
           pCtx: WasmPointer,
-          eConflict: number /* TODO: Can be more specific? */,
-        ) => number)
+          eConflict:
+            | CAPI['SQLITE_CHANGESET_DATA']
+            | CAPI['SQLITE_CHANGESET_NOTFOUND']
+            | CAPI['SQLITE_CHANGESET_CONFLICT']
+            | CAPI['SQLITE_CHANGESET_FOREIGN_KEY']
+            | CAPI['SQLITE_CHANGESET_CONSTRAINT'],
+          ) => number)
       | WasmPointer,
     pCtx: WasmPointer,
   ) => number;
@@ -7345,7 +7360,12 @@ declare type CAPI = {
     xConflict:
       | ((
           pCtx: WasmPointer,
-          eConflict: number /* TODO: Can be more specific? */,
+          eConflict:
+            | CAPI['SQLITE_CHANGESET_DATA']
+            | CAPI['SQLITE_CHANGESET_NOTFOUND']
+            | CAPI['SQLITE_CHANGESET_CONFLICT']
+            | CAPI['SQLITE_CHANGESET_FOREIGN_KEY']
+            | CAPI['SQLITE_CHANGESET_CONSTRAINT'],
         ) => number)
       | WasmPointer,
     pCtx: WasmPointer,


### PR DESCRIPTION
I've resolved a couple of TODOs left behind and added more specific types for `eConflict` parameter

References: https://github.com/sqlite/sqlite/blob/03c0ac435e2e18f177057cf634839092d35196ce/ext/session/sqlite3session.h#L1430-L1434
https://github.com/sqlite/sqlite/blob/03c0ac435e2e18f177057cf634839092d35196ce/ext/session/changeset.c#L157-L163