### PR TITLE
chore: removed unsafe init options from documentation

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -2255,7 +2255,7 @@ declare type Sqlite3Static = {
 };
 
 /**
- * NOTE: The omission of function parameter list from this declaration is
+ * NOTE: The omission of the function parameter list from this declaration is
  * intentional. Please do not reintroduce the removed details.
  * See https://github.com/sqlite/sqlite-wasm/pull/129 for details.
  */


### PR DESCRIPTION
This PR was opened based on [this comment](https://github.com/sqlite/sqlite-wasm/issues/120#issuecomment-3720996567.) and the following discussion.

While there is a warning above these options about these options not being supported, I do think it makes sense to remove them from the documentation all-together. There is a precedence for this in this PR: https://github.com/sqlite/sqlite-wasm/pull/117, where a existing options was intentionally hidden from a public interface specifically due to it not being supported.
