### PR TITLE
fix: added workflow permissions to build-wasm.yml

### DIFF
--- a/.github/workflows/build-wasm.yml
+++ b/.github/workflows/build-wasm.yml
@@ -8,6 +8,10 @@ on:
         required: true
         default: 'master'
 
+permissions:
+  contents: write
+  pull-requests: write
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
I think this should fix failing build-wasm workflow runs