### PR TITLE
chore: tightened GitHub Actions permissions

### DIFF
--- a/.github/workflows/build-wasm.yml
+++ b/.github/workflows/build-wasm.yml
@@ -4,17 +4,17 @@ on:
   workflow_dispatch:
     inputs:
       sqlite_ref:
-        description: 'SQLite reference (tag, branch, or commit, or "latest")'
+        description: 'Full commit SHA from SQLite repository'
         required: true
-        default: 'master'
 
-permissions:
-  contents: write
-  pull-requests: write
+permissions: {}
 
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
@@ -25,23 +25,15 @@ jobs:
         id: resolve-ref
         run: |
           SQLITE_REF="${{ github.event.inputs.sqlite_ref }}"
-          if [ "$SQLITE_REF" = "latest" ]; then
-            echo "Fetching latest tag..."
-            LATEST_TAG=$(git ls-remote --tags --sort="v:refname" https://github.com/sqlite/sqlite.git "refs/tags/version-*" | tail -n 1 | cut -f 2 | sed 's/refs\/tags\///')
-            echo "Latest tag found: $LATEST_TAG"
-            SQLITE_REF="$LATEST_TAG"
+          if ! [[ "$SQLITE_REF" =~ ^[0-9a-fA-F]{40}$ ]]; then
+            echo "Expected a full 40-character commit SHA, got: '$SQLITE_REF'"
+            exit 1
           fi
 
-          # Get the full commit SHA
           SQLITE_SHA=$(git ls-remote https://github.com/sqlite/sqlite.git "$SQLITE_REF" | head -n 1 | cut -f 1)
-          if [ -z "$SQLITE_SHA" ]; then
-            # If not found, maybe it's a tag that needs refs/tags/ prefix or it's already a SHA
-            SQLITE_SHA=$(git ls-remote https://github.com/sqlite/sqlite.git "refs/tags/$SQLITE_REF" | head -n 1 | cut -f 1)
-          fi
-
-          if [ -z "$SQLITE_SHA" ]; then
-            # Fallback: assume it's a SHA if ls-remote didn't find it as a ref
-            SQLITE_SHA="$SQLITE_REF"
+          if [ -z "$SQLITE_SHA" ] || [ "$SQLITE_SHA" != "$SQLITE_REF" ]; then
+            echo "Commit SHA '$SQLITE_REF' was not found in https://github.com/sqlite/sqlite.git"
+            exit 1
           fi
 
           echo "sqlite_ref=$SQLITE_REF" >> $GITHUB_OUTPUT
@@ -70,8 +62,6 @@ jobs:
           context: .
           load: true
           tags: sqlite-wasm-builder:env
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
 
       - name: Run build
         if: steps.check-branch.outputs.skip != 'true'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,8 +1,6 @@
 name: CI
 
-permissions:
-  contents: read
-  pull-requests: read
+permissions: {}
 
 on:
   push:
@@ -22,6 +20,8 @@ jobs:
   type-check:
     name: Type check
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Checkout repo
         uses: actions/checkout@v6
@@ -37,6 +37,8 @@ jobs:
   format:
     name: Format check
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Checkout repo
         uses: actions/checkout@v6
@@ -52,6 +54,8 @@ jobs:
   test-browser:
     name: Run browser tests
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Checkout repo
         uses: actions/checkout@v6
@@ -92,6 +96,8 @@ jobs:
   test-node:
     name: Run node tests (Node ${{ matrix.node-version }})
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,38 @@
+name: Publish package
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+
+permissions: {}
+
+jobs:
+  publish-npm:
+    name: Publish to npm (OIDC)
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Setup environment (node + install)
+        uses: ./.github/actions/node-setup
+        with:
+          node-version: 24
+
+      - name: Build and validate package
+        run: npm run prepublishOnly
+
+      - name: Configure npm for OIDC trusted publishing
+        uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          registry-url: https://registry.npmjs.org
+
+      - name: Publish to npm
+        run: npm publish --provenance --access public


### PR DESCRIPTION
Based on today's attacks on npm ecosystem, through GH Actions, I've tightened the workflows a tiny bit. Permissions are now assigned per task, you'll need a full sha of the commit for the build (in case upstream tags get highjacked somehow) and added OIDC publishing, although I think that needs setting up on npm side as well.